### PR TITLE
fixed pitchSpectrum crash

### DIFF
--- a/ledfx/effects/pitchSpectrum.py
+++ b/ledfx/effects/pitchSpectrum.py
@@ -45,7 +45,7 @@ class PitchSpectrumAudioEffect(AudioReactiveEffect, GradientEffect):
         # Grab the note color based on where it falls in the midi range
         if self.avg_midi >= MIN_MIDI:
             midi_scaled = (self.avg_midi - MIN_MIDI) / (MAX_MIDI - MIN_MIDI)
-            note_color = self.get_gradient_color(midi_scaled)
+            note_color = self.get_gradient_color(int(midi_scaled*100))
 
         # Mix in the new color based on the filterbank information and fade out
         # the old colors


### PR DESCRIPTION
Line 48:

added int(midi_scaled*100) instead of just midi_scaled since get_gradient_color expects an int and midi_scaled is always under 1.